### PR TITLE
Add yard documentation

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,4 @@
+--no-private
+lib/**/*.rb
+examples/*.rb - 
+README.md CONTRIBUTING.md CHANGELOG.md

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
+    yard (0.9.25)
     zeitwerk (2.4.0)
 
 PLATFORMS
@@ -100,6 +101,7 @@ DEPENDENCIES
   rspec (~> 3.9)
   rubocop
   rubocop-performance
+  yard (~> 0.9)
 
 BUNDLED WITH
    2.1.4

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Camper is a Ruby wrapper for the [Basecamp 3 API](https://github.com/basecamp/bc3-api).
 
+You can check out the gem documentation at [https://www.rubydoc.org/gems/camper](https://www.rubydoc.org/gems/camper)
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/camper.gemspec
+++ b/camper.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'
+  spec.add_development_dependency 'yard', '~> 0.9'
 end

--- a/lib/camper/api/todo.rb
+++ b/lib/camper/api/todo.rb
@@ -51,7 +51,11 @@ class Camper::Client
     # @example
     #   client.create_todo(todolist, 'First Todo')
     # @example
-    #   client.create_todo(todolist, 'Program it', description: "<div><em>Try that new language!</em></div>, due_on: "2016-05-01")
+    #   client.create_todo(
+    #     todolist,
+    #     'Program it',
+    #     description: "<div><em>Try that new language!</em></div>, due_on: "2016-05-01"
+    #   )
     #
     # @param todolist [Resource] the todolist where the todo is going to be created
     # @param content [String] what the to-do is for

--- a/lib/camper/api/todo.rb
+++ b/lib/camper/api/todo.rb
@@ -3,22 +3,72 @@
 class Camper::Client
   module TodoAPI
 
-    def todolists(todoset)
-      get(todoset.todolists_url, override_path: true)
+    # Get the todolists associated with the todoset
+    #
+    # @example
+    #   client.todolists(todoset)
+    # @example
+    #   client.todolists(todoset, status: 'archived')
+    #
+    # @param todoset [Resource] the parent todoset resource
+    # @param options [Hash] extra options to filter the list of todolist
+    # @return [Array<Resource>]
+    # @see https://github.com/basecamp/bc3-api/blob/master/sections/todolists.md#get-to-do-lists
+    def todolists(todoset, options={})
+      get(todoset.todolists_url, options.merge(override_path: true))
     end
 
+    # Get a todolist with a given id
+    #
+    # @example
+    #   client.todolist(todoset, '2345')
+    #
+    # @param todoset [Resource] the parent todoset resource
+    # @param id [Integer, String] the id of the todolist to get
+    # @return [Resource]
+    # @see https://github.com/basecamp/bc3-api/blob/master/sections/todolists.md#get-a-to-do-list
     def todolist(todoset, id)
       get("/buckets/#{todoset.bucket.id}/todolists/#{id}")
     end
 
+    # Get the todos in a todolist
+    #
+    # @example
+    #   client.todos(todolist)
+    # @example
+    #   client.todos(todolist, completed: true)
+    #
+    # @param todolist [Resource] the parent todoset resource
+    # @param options [Hash] options to filter the list of todos
+    # @return [Resource]
+    # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#get-to-dos
     def todos(todolist, options={})
       get(todolist.todos_url, options.merge(override_path: true))
     end
 
+    # Create a todo within a todolist
+    #
+    # @example
+    #   client.create_todo(todolist, 'First Todo')
+    # @example
+    #   client.create_todo(todolist, 'Program it', description: "<div><em>Try that new language!</em></div>, due_on: "2016-05-01")
+    #
+    # @param todolist [Resource] the todolist where the todo is going to be created
+    # @param content [String] what the to-do is for
+    # @param options [Hash] extra configuration for the todo such as due_date and description
+    # @return [Resource]
+    # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#create-a-to-do
     def create_todo(todolist, content, options={})
       post(todolist.todos_url, body: { content: content, **options }, override_path: true)
     end
 
+    # Complete a todo
+    #
+    # @example
+    #   client.complete_todo(todo)
+    #
+    # @param todo [Resource] the todo to be marked as completed
+    # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#complete-a-to-do
     def complete_todo(todo)
       post("#{todo.url}/completion", override_path: true)
     end

--- a/lib/camper/client.rb
+++ b/lib/camper/client.rb
@@ -19,7 +19,7 @@ module Camper
     include ResourceAPI
     include TodoAPI
 
-    # Creates a new API.
+    # Creates a new Client instance.
     # @raise [Error:MissingCredentials]
     def initialize(options = {})
       @config = Configuration.new(options)
@@ -38,7 +38,8 @@ module Camper
     end
 
     # Allows setting configuration values for this client
-    # returns the client instance being configured
+    # by yielding the config object to the block
+    # @return [Camper::Client] the client instance being configured
     def configure
       yield @config
 
@@ -52,14 +53,6 @@ module Camper
       inspected = super
       inspected.sub! @config.access_token, only_show_last_four_chars(@config.access_token) if @config.access_token
       inspected
-    end
-
-    # Utility method for URL encoding of a string.
-    # Copied from https://ruby-doc.org/stdlib-2.7.0/libdoc/erb/rdoc/ERB/Util.html
-    #
-    # @return [String]
-    def url_encode(url)
-      url.to_s.b.gsub(/[^a-zA-Z0-9_\-.~]/n) { |m| sprintf('%%%02X', m.unpack1('C')) } # rubocop:disable Style/FormatString, Style/FormatStringToken
     end
 
     private

--- a/lib/camper/pagination_data.rb
+++ b/lib/camper/pagination_data.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 module Camper
-  # Parses link header.
-  #
-  # @private
   class PaginationData
     include Logging
 


### PR DESCRIPTION
## Description

Fix #6

The documentation has already been enabled at https://www.rubydoc.org/gems/camper/

## Changes

### Yard
* Add yard gem
* Add yardopts for yard config

### Docs
* Add docs for Todo api

### Client
* Remove unused method