### PR TITLE
Raise error if resource can't be commented

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    camper (0.0.5)
+    camper (0.0.7)
       httparty (~> 0.18)
       rack-oauth2 (~> 1.14)
 

--- a/lib/camper/api/comment.rb
+++ b/lib/camper/api/comment.rb
@@ -3,6 +3,8 @@
 class Camper::Client
   module CommentAPI
     def create_comment(resource, content)
+      raise Error::ResourceCannotBeCommented, resource unless resource.can_be_commented?
+
       post(resource.comments_url, override_path: true, body: { content: content })
     end
 

--- a/lib/camper/error.rb
+++ b/lib/camper/error.rb
@@ -13,6 +13,8 @@ module Camper
 
     class MissingBody < Error; end
 
+    class ResourceCannotBeCommented < Error; end
+
     # Raised when impossible to parse response body.
     class Parsing < Error; end
 


### PR DESCRIPTION
## Changes

* Raise errors if `create_comment` is called on resource that does not support comments