### PR TITLE
Add people API

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ Or install it yourself as:
 $ gem install camper
 ```
 
+## Implemented API endpoints
+
+The up-to-date list of Basecamp API endpoints can be found at [here](https://github.com/basecamp/bc3-api#api-endpoints).
+
+Currently, Camper supports the following endpoints:
+
+* [Comments](https://github.com/basecamp/bc3-api/blob/master/sections/comments.md): Implementation at [comments.rb](./lib/camper/api/comments.rb) **Partial**
+* [Messages](https://github.com/basecamp/bc3-api/blob/master/sections/messages.md): Implementation at [messages.rb](./lib/camper/api/messages.rb) **Partial**
+* [People](https://github.com/basecamp/bc3-api/blob/master/sections/people.md): Implementation at [people.rb](./lib/camper/api/people.rb) **Complete**
+* [Projects](https://github.com/basecamp/bc3-api/blob/master/sections/projects.md): Implementation at [projects.rb](./lib/camper/api/projects.rb) **Partial**
+* [To-dos](https://github.com/basecamp/bc3-api/blob/master/sections/todos.md): Implementation at [todos.rb](./lib/camper/api/todos.rb) **Partial**
+
 ## Usage
 
 ### Configuration

--- a/lib/camper/api/comments.rb
+++ b/lib/camper/api/comments.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Camper::Client
-  module CommentAPI
+  module CommentsAPI
     def create_comment(resource, content)
       raise Error::ResourceCannotBeCommented, resource unless resource.can_be_commented?
 

--- a/lib/camper/api/messages.rb
+++ b/lib/camper/api/messages.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Camper::Client
-  module MessageAPI
+  module MessagesAPI
     def messages(message_board)
       get(message_board.messages_url, override_path: true)
     end

--- a/lib/camper/api/people.rb
+++ b/lib/camper/api/people.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+class Camper::Client
+  # Defines methods related to people.
+  # @see ttps://github.com/basecamp/bc3-api/blob/master/sections/people.md
+  module PeopleAPI
+
+    # Get all people visible to the current user
+    #
+    # @example
+    #   client.people
+    #
+    # @return [Array<Resource>]
+    # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md#get-all-people
+    def people
+      get("/people")
+    end
+
+    # Get all active people on the project with the given ID
+    #
+    # @example
+    #   client.people_in_project(10)
+    # @example
+    #   client.people_in_project("20")
+    # @example
+    #   client.people_in_project(my_project)
+    #
+    # @param project [Resource|Integer|String] A project resource or a project id
+    # @return [Array<Resource>]
+    # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md#get-people-on-a-project
+    def people_in_project(project)
+      id = project.respond_to? :id ? project.id : project
+
+      get("/projects/#{id}/people")
+    end
+
+    # Allows granting new and existing people access to a project, and revoking access from existing people.
+    #
+    # @example
+    #   client.update_access_in_project(10, { grant: [102, 127] })
+    # @example
+    #   client.update_access_in_project("8634", { revoke: [300, 12527] })
+    # @example
+    #   client.update_access_in_project(my_project, { create: [{ name: "Victor Copper", email_address: "victor@hanchodesign.com" }]})
+    #
+    # @param project [Resource|Integer|String] A project resource or a project id
+    # @param options [Hash] options to update access, either grant, revoke or create new people
+    # @return [Resource]
+    # @raise [Error::RequestIsMissingParameters] if no option is specified
+    # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md#update-who-can-access-a-project
+    def update_access_in_project(project, options = {})
+      raise RequestIsMissingParameters, "options cannot be empty" if options.empty?
+
+      id = project.respond_to? :id ? project.id : project
+
+      put("/projects/#{id}/people/users", body: { **options})
+    end
+
+    # Get all people on this Basecamp account who can be pinged
+    #
+    # @example
+    #   client.pingable_people
+    #
+    # @return [Array<Resource>]
+    # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md#get-pingable-people
+    def pingable_people
+      get("/circles/people")
+    end
+
+    # Get the profile for the user with the given ID
+    #
+    # @example
+    #   client.person(234790)
+    #
+    # @param id [Integer|String] A user id
+    # @return [Resource]
+    # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md#get-person
+    def person(id)
+      get("/people/#{id}")
+    end
+
+    # Get the current user's personal info.
+    #
+    # @example
+    #   client.profile
+    #
+    # @return [Resource]
+    # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md#get-my-personal-info
+    def profile
+      get("/my/profile")
+    end
+  end
+end

--- a/lib/camper/api/people.rb
+++ b/lib/camper/api/people.rb
@@ -13,7 +13,7 @@ class Camper::Client
     # @return [Array<Resource>]
     # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md#get-all-people
     def people
-      get("/people")
+      get('/people')
     end
 
     # Get all active people on the project with the given ID
@@ -29,7 +29,7 @@ class Camper::Client
     # @return [Array<Resource>]
     # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md#get-people-on-a-project
     def people_in_project(project)
-      id = project.respond_to? :id ? project.id : project
+      id = project.respond_to?(:id) ? project.id : project
 
       get("/projects/#{id}/people")
     end
@@ -51,9 +51,9 @@ class Camper::Client
     def update_access_in_project(project, options = {})
       raise RequestIsMissingParameters, "options cannot be empty" if options.empty?
 
-      id = project.respond_to? :id ? project.id : project
+      id = project.respond_to?(:id) ? project.id : project
 
-      put("/projects/#{id}/people/users", body: { **options})
+      put("/projects/#{id}/people/users", body: { **options })
     end
 
     # Get all people on this Basecamp account who can be pinged
@@ -64,7 +64,7 @@ class Camper::Client
     # @return [Array<Resource>]
     # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md#get-pingable-people
     def pingable_people
-      get("/circles/people")
+      get('/circles/people')
     end
 
     # Get the profile for the user with the given ID
@@ -87,7 +87,7 @@ class Camper::Client
     # @return [Resource]
     # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md#get-my-personal-info
     def profile
-      get("/my/profile")
+      get('/my/profile')
     end
   end
 end

--- a/lib/camper/api/people.rb
+++ b/lib/camper/api/people.rb
@@ -4,7 +4,6 @@ class Camper::Client
   # Defines methods related to people.
   # @see ttps://github.com/basecamp/bc3-api/blob/master/sections/people.md
   module PeopleAPI
-
     # Get all people visible to the current user
     #
     # @example
@@ -41,7 +40,12 @@ class Camper::Client
     # @example
     #   client.update_access_in_project("8634", { revoke: [300, 12527] })
     # @example
-    #   client.update_access_in_project(my_project, { create: [{ name: "Victor Copper", email_address: "victor@hanchodesign.com" }]})
+    #   client.update_access_in_project(my_project, {
+    #     create: [{
+    #       name: "Victor Copper",
+    #       email_address: "victor@hanchodesign.com"
+    #     }]
+    #   })
     #
     # @param project [Resource|Integer|String] A project resource or a project id
     # @param options [Hash] options to update access, either grant, revoke or create new people
@@ -49,7 +53,7 @@ class Camper::Client
     # @raise [Error::RequestIsMissingParameters] if no option is specified
     # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md#update-who-can-access-a-project
     def update_access_in_project(project, options = {})
-      raise RequestIsMissingParameters, "options cannot be empty" if options.empty?
+      raise RequestIsMissingParameters, 'options cannot be empty' if options.empty?
 
       id = project.respond_to?(:id) ? project.id : project
 

--- a/lib/camper/api/projects.rb
+++ b/lib/camper/api/projects.rb
@@ -2,9 +2,8 @@
 
 class Camper::Client
   module ProjectsAPI
-
     def projects(options = {})
-      get("/projects", options)
+      get('/projects', options)
     end
 
     def project(id)

--- a/lib/camper/api/projects.rb
+++ b/lib/camper/api/projects.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Camper::Client
-  module ProjectAPI
+  module ProjectsAPI
 
     def projects(options = {})
       get("/projects", options)

--- a/lib/camper/api/todos.rb
+++ b/lib/camper/api/todos.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Camper::Client
-  module TodoAPI
+  module TodosAPI
 
     # Get the todolists associated with the todoset
     #

--- a/lib/camper/api/todos.rb
+++ b/lib/camper/api/todos.rb
@@ -2,7 +2,6 @@
 
 class Camper::Client
   module TodosAPI
-
     # Get the todolists associated with the todoset
     #
     # @example
@@ -14,7 +13,7 @@ class Camper::Client
     # @param options [Hash] extra options to filter the list of todolist
     # @return [Array<Resource>]
     # @see https://github.com/basecamp/bc3-api/blob/master/sections/todolists.md#get-to-do-lists
-    def todolists(todoset, options={})
+    def todolists(todoset, options = {})
       get(todoset.todolists_url, options.merge(override_path: true))
     end
 
@@ -42,7 +41,7 @@ class Camper::Client
     # @param options [Hash] options to filter the list of todos
     # @return [Resource]
     # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#get-to-dos
-    def todos(todolist, options={})
+    def todos(todolist, options = {})
       get(todolist.todos_url, options.merge(override_path: true))
     end
 
@@ -62,7 +61,7 @@ class Camper::Client
     # @param options [Hash] extra configuration for the todo such as due_date and description
     # @return [Resource]
     # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#create-a-to-do
-    def create_todo(todolist, content, options={})
+    def create_todo(todolist, content, options = {})
       post(todolist.todos_url, body: { content: content, **options }, override_path: true)
     end
 

--- a/lib/camper/client.rb
+++ b/lib/camper/client.rb
@@ -12,12 +12,13 @@ module Camper
 
     # Keep in alphabetical order
     include Authorization
-    include CommentAPI
+    include CommentsAPI
     include Logging
-    include MessageAPI
-    include ProjectAPI
+    include MessagesAPI
+    include PeopleAPI
+    include ProjectsAPI
     include ResourceAPI
-    include TodoAPI
+    include TodosAPI
 
     # Creates a new Client instance.
     # @raise [Error:MissingCredentials]

--- a/lib/camper/error.rb
+++ b/lib/camper/error.rb
@@ -15,6 +15,8 @@ module Camper
 
     class ResourceCannotBeCommented < Error; end
 
+    class RequestIsMissingParameters < Error; end
+
     # Raised when impossible to parse response body.
     class Parsing < Error; end
 


### PR DESCRIPTION
## Description

Implements the people API at https://github.com/basecamp/bc3-api/blob/master/sections/people.md

## Changes

* Implements people endpoints fully with comments
* Renames API modules to plural equivalents
* Add API Implementation section in README
* Add new `RequestIsMissingParameters` error type