### PR TITLE
Fix query string generation in get endpoints

### DIFF
--- a/examples/todolists.rb
+++ b/examples/todolists.rb
@@ -13,7 +13,7 @@ projects.auto_paginate do |p|
 
   puts "Ratio of completed Todos in Todoset: #{todoset.completed_ratio}"
 
-  puts "Listing active todolists"
+  puts 'Listing active todolists'
   client.todolists(todoset).auto_paginate(5) do |list|
     puts "Todolist: #{list.title}"
 
@@ -31,7 +31,7 @@ projects.auto_paginate do |p|
     puts 'Cannot use a project p to get the todolists'
   end
 
-  puts "Listing archived todolists"
+  puts 'Listing archived todolists'
   client.todolists(todoset, status: :archived).auto_paginate do |list|
     client.todos(list).auto_paginate do |todo|
       puts "Todo: #{todo.title}"

--- a/examples/todolists.rb
+++ b/examples/todolists.rb
@@ -13,6 +13,7 @@ projects.auto_paginate do |p|
 
   puts "Ratio of completed Todos in Todoset: #{todoset.completed_ratio}"
 
+  puts "Listing active todolists"
   client.todolists(todoset).auto_paginate(5) do |list|
     puts "Todolist: #{list.title}"
 
@@ -26,7 +27,18 @@ projects.auto_paginate do |p|
 
   begin
     client.todolists(p)
-  rescue Camper::Error::InvalidParameter
+  rescue Camper::Error::InvalidParameter, NoMethodError
     puts 'Cannot use a project p to get the todolists'
+  end
+
+  puts "Listing archived todolists"
+  client.todolists(todoset, status: :archived).auto_paginate do |list|
+    client.todos(list).auto_paginate do |todo|
+      puts "Todo: #{todo.title}"
+      puts "Can be commented: #{todo.can_be_commented?}"
+      puts "It's completed: #{todo.completed}"
+
+      client.complete_todo(todo)
+    end
   end
 end

--- a/lib/camper/api/projects.rb
+++ b/lib/camper/api/projects.rb
@@ -15,7 +15,7 @@ class Camper::Client
     # @return [Array<Project>]
     # @see https://github.com/basecamp/bc3-api/blob/master/sections/projects.md#get-all-projects
     def projects(options = {})
-      get('/projects', options)
+      get('/projects', query: options)
     end
 
     # Get a project with a given id, granted they have access to it

--- a/lib/camper/api/todolists.rb
+++ b/lib/camper/api/todolists.rb
@@ -22,7 +22,7 @@ class Camper::Client
 
       raise Camper::Error::InvalidParameter, todoset unless Camper::UrlUtils.basecamp_url?(url)
 
-      get(url, options.merge(override_path: true))
+      get(url, query: options, override_path: true)
     end
 
     # Get a todolist with a given id

--- a/lib/camper/api/todos.rb
+++ b/lib/camper/api/todos.rb
@@ -32,7 +32,7 @@ class Camper::Client
 
       raise Camper::Error::InvalidParameter, todolist unless Camper::UrlUtils.basecamp_url?(url)
 
-      get(url, options.merge(override_path: true))
+      get(url, query: options, override_path: true)
     end
 
     # Get a todo with a given id using a particular parent resource.


### PR DESCRIPTION
## Description

Fix #54 

## Changes

* Added top-level `query in hash passed down to `get` method
* Expand `todolists` example