### PR TITLE
Rewrite API modules to use module nesting

### DIFF
--- a/lib/camper/api/comments.rb
+++ b/lib/camper/api/comments.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
-class Camper::Client
-  module CommentsAPI
-    def create_comment(resource, content)
-      raise Error::ResourceCannotBeCommented, resource unless resource.can_be_commented?
+module Camper
+  class Client
+    module CommentsAPI
+      def create_comment(resource, content)
+        raise Error::ResourceCannotBeCommented, resource unless resource.can_be_commented?
 
-      post(resource.comments_url, override_path: true, body: { content: content })
-    end
+        post(resource.comments_url, override_path: true, body: { content: content })
+      end
 
-    def comments(resource)
-      get(resource.comments_url, override_path: true)
+      def comments(resource)
+        get(resource.comments_url, override_path: true)
+      end
     end
   end
 end

--- a/lib/camper/api/messages.rb
+++ b/lib/camper/api/messages.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-class Camper::Client
-  module MessagesAPI
-    def messages(message_board)
-      get(message_board.messages_url, override_path: true)
+module Camper
+  class Client
+    module MessagesAPI
+      def messages(message_board)
+        get(message_board.messages_url, override_path: true)
+      end
     end
   end
 end

--- a/lib/camper/api/people.rb
+++ b/lib/camper/api/people.rb
@@ -1,97 +1,99 @@
 # frozen_string_literal: true
 
-class Camper::Client
-  # Defines methods related to people.
-  # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md
-  module PeopleAPI
-    # Get all people visible to the current user
-    #
-    # @example
-    #   client.people
-    #
-    # @return [PaginatedResponse<Resource>]
-    # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md#get-all-people
-    def people
-      get('/people')
-    end
+module Camper
+  class Client
+    # Defines methods related to people.
+    # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md
+    module PeopleAPI
+      # Get all people visible to the current user
+      #
+      # @example
+      #   client.people
+      #
+      # @return [PaginatedResponse<Resource>]
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md#get-all-people
+      def people
+        get('/people')
+      end
 
-    # Get all active people on the project with the given ID
-    #
-    # @example
-    #   client.people_in_project(10)
-    # @example
-    #   client.people_in_project("20")
-    # @example
-    #   client.people_in_project(my_project)
-    #
-    # @param project [Resource|Integer|String] A project resource or a project id
-    # @return [PaginatedResponse<Resource>]
-    # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md#get-people-on-a-project
-    def people_in_project(project)
-      id = project.respond_to?(:id) ? project.id : project
+      # Get all active people on the project with the given ID
+      #
+      # @example
+      #   client.people_in_project(10)
+      # @example
+      #   client.people_in_project("20")
+      # @example
+      #   client.people_in_project(my_project)
+      #
+      # @param project [Resource|Integer|String] A project resource or a project id
+      # @return [PaginatedResponse<Resource>]
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md#get-people-on-a-project
+      def people_in_project(project)
+        id = project.respond_to?(:id) ? project.id : project
 
-      get("/projects/#{id}/people")
-    end
+        get("/projects/#{id}/people")
+      end
 
-    # Allows granting new and existing people access to a project, and revoking access from existing people.
-    #
-    # @example
-    #   client.update_access_in_project(10, { grant: [102, 127] })
-    # @example
-    #   client.update_access_in_project("8634", { revoke: [300, 12527] })
-    # @example
-    #   client.update_access_in_project(my_project, {
-    #     create: [{
-    #       name: "Victor Copper",
-    #       email_address: "victor@hanchodesign.com"
-    #     }]
-    #   })
-    #
-    # @param project [Resource|Integer|String] A project resource or a project id
-    # @param options [Hash] options to update access, either grant, revoke or create new people
-    # @return [Resource]
-    # @raise [Error::InvalidParameter] if no option is specified
-    # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md#update-who-can-access-a-project
-    def update_access_in_project(project, options = {})
-      raise Camper::Error::InvalidParameter, 'options cannot be empty' if options.empty?
+      # Allows granting new and existing people access to a project, and revoking access from existing people.
+      #
+      # @example
+      #   client.update_access_in_project(10, { grant: [102, 127] })
+      # @example
+      #   client.update_access_in_project("8634", { revoke: [300, 12527] })
+      # @example
+      #   client.update_access_in_project(my_project, {
+      #     create: [{
+      #       name: "Victor Copper",
+      #       email_address: "victor@hanchodesign.com"
+      #     }]
+      #   })
+      #
+      # @param project [Resource|Integer|String] A project resource or a project id
+      # @param options [Hash] options to update access, either grant, revoke or create new people
+      # @return [Resource]
+      # @raise [Error::InvalidParameter] if no option is specified
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md#update-who-can-access-a-project
+      def update_access_in_project(project, options = {})
+        raise Camper::Error::InvalidParameter, 'options cannot be empty' if options.empty?
 
-      id = project.respond_to?(:id) ? project.id : project
+        id = project.respond_to?(:id) ? project.id : project
 
-      put("/projects/#{id}/people/users", body: { **options })
-    end
+        put("/projects/#{id}/people/users", body: { **options })
+      end
 
-    # Get all people on this Basecamp account who can be pinged
-    #
-    # @example
-    #   client.pingable_people
-    #
-    # @return [PaginatedResponse<Resource>]
-    # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md#get-pingable-people
-    def pingable_people
-      get('/circles/people')
-    end
+      # Get all people on this Basecamp account who can be pinged
+      #
+      # @example
+      #   client.pingable_people
+      #
+      # @return [PaginatedResponse<Resource>]
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md#get-pingable-people
+      def pingable_people
+        get('/circles/people')
+      end
 
-    # Get the profile for the user with the given ID
-    #
-    # @example
-    #   client.person(234790)
-    #
-    # @param id [Integer|String] A user id
-    # @return [Resource]
-    # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md#get-person
-    def person(id)
-      get("/people/#{id}")
-    end
+      # Get the profile for the user with the given ID
+      #
+      # @example
+      #   client.person(234790)
+      #
+      # @param id [Integer|String] A user id
+      # @return [Resource]
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md#get-person
+      def person(id)
+        get("/people/#{id}")
+      end
 
-    # Get the current user's personal info.
-    #
-    # @example
-    #   client.profile
-    #
-    # @return [Resource]
-    # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md#get-my-personal-info
-    def profile
-      get('/my/profile')
+      # Get the current user's personal info.
+      #
+      # @example
+      #   client.profile
+      #
+      # @return [Resource]
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/people.md#get-my-personal-info
+      def profile
+        get('/my/profile')
+      end
     end
   end
 end

--- a/lib/camper/api/projects.rb
+++ b/lib/camper/api/projects.rb
@@ -1,120 +1,122 @@
 # frozen_string_literal: true
 
-class Camper::Client
-  # Defines methods related to projects.
-  # @see https://github.com/basecamp/bc3-api/blob/master/sections/projects.md
-  module ProjectsAPI
-    # Get the projects visible to the current user
-    #
-    # @example
-    #   client.projects
-    # @example
-    #   client.projects(status: 'trashed')
-    #
-    # @param options [Hash] extra options to filter the list of todolist
-    # @return [PaginatedResponse<Project>]
-    # @see https://github.com/basecamp/bc3-api/blob/master/sections/projects.md#get-all-projects
-    def projects(options = {})
-      get('/projects', query: options)
-    end
-
-    # Get a project with a given id, granted they have access to it
-    #
-    # @example
-    #   client.project(82564)
-    # @example
-    #   client.project('7364183')
-    #
-    # @param id [Integet|String] id of the project to retrieve
-    # @return [Project]
-    # @raise [Error::InvalidParameter] if id is blank (nil or empty string)
-    # @see https://github.com/basecamp/bc3-api/blob/master/sections/projects.md#get-a-project
-    def project(id)
-      raise Camper::Error::InvalidParameter, id if id.blank?
-
-      get("/projects/#{id}")
-    end
-
-    # Create a project
-    #
-    # @example
-    #   client.create_project("Marketing Campaign")
-    # @example
-    #   client.create_project('Better Marketing Campaign', "For Client: XYZ")
-    #
-    # @param name [String] name of the project to create
-    # @param description [String] description of the project
-    # @return [Project]
-    # @raise [Error::InvalidParameter] if name is blank (nil or empty string)
-    # @see https://github.com/basecamp/bc3-api/blob/master/sections/projects.md#create-a-project
-    def create_project(name, description = '')
-      raise Camper::Error::InvalidParameter, name if name.blank?
-
-      post('/projects', body: { name: name, description: description })
-    end
-
-    # Update a project
-    #  description can be set to empty by passing an empty string
-    #
-    # @example
-    #   client.update_project(12324, name: 'Retros')
-    # @example
-    #   client.update_project('157432', description: 'A new description')
-    # @example
-    #   client.update_project('157432', description: '')
-    # @example
-    #   client.update_project(my_project, name: 'A new name', description: 'A new description')
-    #
-    # @param project [Integer|String|Project] either a project object or a project id
-    # @param name [String] optional new name of the project
-    # @param description [String] optinal new description of the project
-    # @return [Project]
-    # @raise [Error::InvalidParameter] if both name and description are blank (nil or empty strings)
-    # @see https://github.com/basecamp/bc3-api/blob/master/sections/projects.md#update-a-project
-    def update_project(project, name: '', description: nil)
-      if name.blank? && description.blank?
-        raise Camper::Error::InvalidParameter, 'name and description cannot both be blank'
+module Camper
+  class Client
+    # Defines methods related to projects.
+    # @see https://github.com/basecamp/bc3-api/blob/master/sections/projects.md
+    module ProjectsAPI
+      # Get the projects visible to the current user
+      #
+      # @example
+      #   client.projects
+      # @example
+      #   client.projects(status: 'trashed')
+      #
+      # @param options [Hash] extra options to filter the list of todolist
+      # @return [PaginatedResponse<Project>]
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/projects.md#get-all-projects
+      def projects(options = {})
+        get('/projects', query: options)
       end
 
-      id = project.respond_to?(:id) ? project.id : project
+      # Get a project with a given id, granted they have access to it
+      #
+      # @example
+      #   client.project(82564)
+      # @example
+      #   client.project('7364183')
+      #
+      # @param id [Integet|String] id of the project to retrieve
+      # @return [Project]
+      # @raise [Error::InvalidParameter] if id is blank (nil or empty string)
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/projects.md#get-a-project
+      def project(id)
+        raise Error::InvalidParameter, id if id.blank?
 
-      options = {}
-      options[:name] = name unless name.blank?
-      options[:description] = description unless description.nil?
+        get("/projects/#{id}")
+      end
 
-      put("/projects/#{id}", body: { **options })
-    end
+      # Create a project
+      #
+      # @example
+      #   client.create_project("Marketing Campaign")
+      # @example
+      #   client.create_project('Better Marketing Campaign', "For Client: XYZ")
+      #
+      # @param name [String] name of the project to create
+      # @param description [String] description of the project
+      # @return [Project]
+      # @raise [Error::InvalidParameter] if name is blank (nil or empty string)
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/projects.md#create-a-project
+      def create_project(name, description = '')
+        raise Error::InvalidParameter, name if name.blank?
 
-    # Delete a project
-    #
-    # @example
-    #   client.delete_project(12324)
-    # @example
-    #   client.delete_project('157432')
-    # @example
-    #   client.delete_project(my_project)
-    #
-    # @param project [Integer|String|Project] either a project object or a project id
-    # @raise [Error::InvalidParameter] if project param is blank
-    # @see https://github.com/basecamp/bc3-api/blob/master/sections/projects.md#trash-a-project
-    def delete_project(project)
-      raise Camper::Error::InvalidParameter, 'project cannot be blank' if project.blank?
+        post('/projects', body: { name: name, description: description })
+      end
 
-      id = project.respond_to?(:id) ? project.id : project
+      # Update a project
+      #  description can be set to empty by passing an empty string
+      #
+      # @example
+      #   client.update_project(12324, name: 'Retros')
+      # @example
+      #   client.update_project('157432', description: 'A new description')
+      # @example
+      #   client.update_project('157432', description: '')
+      # @example
+      #   client.update_project(my_project, name: 'A new name', description: 'A new description')
+      #
+      # @param project [Integer|String|Project] either a project object or a project id
+      # @param name [String] optional new name of the project
+      # @param description [String] optinal new description of the project
+      # @return [Project]
+      # @raise [Error::InvalidParameter] if both name and description are blank (nil or empty strings)
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/projects.md#update-a-project
+      def update_project(project, name: '', description: nil)
+        if name.blank? && description.blank?
+          raise Error::InvalidParameter, 'name and description cannot both be blank'
+        end
 
-      delete("/projects/#{id}")
-    end
+        id = project.respond_to?(:id) ? project.id : project
 
-    alias trash_project delete_project
+        options = {}
+        options[:name] = name unless name.blank?
+        options[:description] = description unless description.nil?
 
-    def message_board(project)
-      board = project.message_board
-      get(board.url, override_path: true)
-    end
+        put("/projects/#{id}", body: { **options })
+      end
 
-    def todoset(project)
-      todoset = project.todoset
-      get(todoset.url, override_path: true)
+      # Delete a project
+      #
+      # @example
+      #   client.delete_project(12324)
+      # @example
+      #   client.delete_project('157432')
+      # @example
+      #   client.delete_project(my_project)
+      #
+      # @param project [Integer|String|Project] either a project object or a project id
+      # @raise [Error::InvalidParameter] if project param is blank
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/projects.md#trash-a-project
+      def delete_project(project)
+        raise Error::InvalidParameter, 'project cannot be blank' if project.blank?
+
+        id = project.respond_to?(:id) ? project.id : project
+
+        delete("/projects/#{id}")
+      end
+
+      alias trash_project delete_project
+
+      def message_board(project)
+        board = project.message_board
+        get(board.url, override_path: true)
+      end
+
+      def todoset(project)
+        todoset = project.todoset
+        get(todoset.url, override_path: true)
+      end
     end
   end
 end

--- a/lib/camper/api/projects.rb
+++ b/lib/camper/api/projects.rb
@@ -73,9 +73,12 @@ module Camper
       # @raise [Error::InvalidParameter] if both name and description are blank (nil or empty strings)
       # @see https://github.com/basecamp/bc3-api/blob/master/sections/projects.md#update-a-project
       def update_project(project, name: '', description: nil)
+        # rubocop:disable Style/IfUnlessModifier:
         if name.blank? && description.blank?
           raise Error::InvalidParameter, 'name and description cannot both be blank'
         end
+
+        # rubocop:enable Style/IfUnlessModifier
 
         id = project.respond_to?(:id) ? project.id : project
 

--- a/lib/camper/api/resource.rb
+++ b/lib/camper/api/resource.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-class Camper::Client
-  module ResourceAPI
-    def resource(url)
-      get(url, override_path: true)
+module Camper
+  class Client
+    module ResourceAPI
+      def resource(url)
+        get(url, override_path: true)
+      end
     end
   end
 end

--- a/lib/camper/api/todolists.rb
+++ b/lib/camper/api/todolists.rb
@@ -1,103 +1,105 @@
 # frozen_string_literal: true
 
-class Camper::Client
-  # Defines methods related to todolists.
-  # @see https://github.com/basecamp/bc3-api/blob/master/sections/todolists.md
-  module TodolistsAPI
-    # Get the todolists associated with the todoset
-    #
-    # @example
-    #   client.todolists(todoset)
-    # @example
-    #   client.todolists(todoset, status: 'archived')
-    #
-    # @param todoset [Resource] the parent todoset resource
-    # @param options [Hash] extra options to filter the list of todolist
-    # @return [PaginatedResponse<Resource>]
-    # @raise [Error::InvalidParameter] if todolists_url field in todoset param
-    #   is not a valid basecamp url
-    # @see https://github.com/basecamp/bc3-api/blob/master/sections/todolists.md#get-to-do-lists
-    def todolists(todoset, options = {})
-      url = todoset.todolists_url
+module Camper
+  class Client
+    # Defines methods related to todolists.
+    # @see https://github.com/basecamp/bc3-api/blob/master/sections/todolists.md
+    module TodolistsAPI
+      # Get the todolists associated with the todoset
+      #
+      # @example
+      #   client.todolists(todoset)
+      # @example
+      #   client.todolists(todoset, status: 'archived')
+      #
+      # @param todoset [Resource] the parent todoset resource
+      # @param options [Hash] extra options to filter the list of todolist
+      # @return [PaginatedResponse<Resource>]
+      # @raise [Error::InvalidParameter] if todolists_url field in todoset param
+      #   is not a valid basecamp url
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/todolists.md#get-to-do-lists
+      def todolists(todoset, options = {})
+        url = todoset.todolists_url
 
-      raise Camper::Error::InvalidParameter, todoset unless Camper::UrlUtils.basecamp_url?(url)
+        raise Error::InvalidParameter, todoset unless UrlUtils.basecamp_url?(url)
 
-      get(url, query: options, override_path: true)
-    end
+        get(url, query: options, override_path: true)
+      end
 
-    # Get a todolist with a given id
-    #
-    # @example
-    #   client.todolist(todoset, '2345')
-    #
-    # @param todoset [Resource] the parent todoset resource
-    # @param id [Integer, String] the id of the todolist to get
-    # @return [Resource]
-    # @see https://github.com/basecamp/bc3-api/blob/master/sections/todolists.md#get-a-to-do-list
-    def todolist(todoset, id)
-      get("/buckets/#{todoset.bucket.id}/todolists/#{id}")
-    end
+      # Get a todolist with a given id
+      #
+      # @example
+      #   client.todolist(todoset, '2345')
+      #
+      # @param todoset [Resource] the parent todoset resource
+      # @param id [Integer, String] the id of the todolist to get
+      # @return [Resource]
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/todolists.md#get-a-to-do-list
+      def todolist(todoset, id)
+        get("/buckets/#{todoset.bucket.id}/todolists/#{id}")
+      end
 
-    # Create a todolist within the given todoset
-    #
-    # @example
-    #   client.create_todolist(todoset, 'Launch', "<div><em>Finish it!</em></div>")
-    #
-    # @param todoset [Resource] the parent todoset resource
-    # @param name [String] the name of the new todolist
-    # @param description [String] an optional description for the todolist
-    # @return [Resource]
-    # @raise [Error::InvalidParameter] if todolists_url field in todoset param
-    #   is not a valid basecamp url
-    # @see https://github.com/basecamp/bc3-api/blob/master/sections/todolists.md#create-a-to-do-list
-    def create_todolist(todoset, name, description = '')
-      url = todoset.todolists_url
+      # Create a todolist within the given todoset
+      #
+      # @example
+      #   client.create_todolist(todoset, 'Launch', "<div><em>Finish it!</em></div>")
+      #
+      # @param todoset [Resource] the parent todoset resource
+      # @param name [String] the name of the new todolist
+      # @param description [String] an optional description for the todolist
+      # @return [Resource]
+      # @raise [Error::InvalidParameter] if todolists_url field in todoset param
+      #   is not a valid basecamp url
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/todolists.md#create-a-to-do-list
+      def create_todolist(todoset, name, description = '')
+        url = todoset.todolists_url
 
-      raise Camper::Error::InvalidParameter, todoset unless Camper::UrlUtils.basecamp_url?(url)
+        raise Error::InvalidParameter, todoset unless UrlUtils.basecamp_url?(url)
 
-      post(url, body: { name: name, description: description }, override_path: true)
-    end
+        post(url, body: { name: name, description: description }, override_path: true)
+      end
 
-    # Update a todolist to change name and description
-    #
-    # @example
-    #   client.update_todolist(todolist, 'Launch')
-    # @example
-    #   client.update_todolist(todolist, 'Launch', "<div><em>Finish it!</em></div>")
-    # @example
-    #   client.update_todolist(todolist, 'Launch', '')
-    #
-    # @param todolist [Resource] the todolist resource to update
-    # @param name [String] the new name of the todolist
-    # @param description [String] a new optional description for the todolist. If not specified,
-    #   it will be set to the current description value
-    # @return [Resource]
-    # @raise [Error::InvalidParameter] if url field in todolist param
-    #   is not a valid basecamp url
-    # @see https://github.com/basecamp/bc3-api/blob/master/sections/todolists.md#update-a-to-do-list
-    def update_todolist(todolist, name, description = nil)
-      url = todolist.url
+      # Update a todolist to change name and description
+      #
+      # @example
+      #   client.update_todolist(todolist, 'Launch')
+      # @example
+      #   client.update_todolist(todolist, 'Launch', "<div><em>Finish it!</em></div>")
+      # @example
+      #   client.update_todolist(todolist, 'Launch', '')
+      #
+      # @param todolist [Resource] the todolist resource to update
+      # @param name [String] the new name of the todolist
+      # @param description [String] a new optional description for the todolist. If not specified,
+      #   it will be set to the current description value
+      # @return [Resource]
+      # @raise [Error::InvalidParameter] if url field in todolist param
+      #   is not a valid basecamp url
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/todolists.md#update-a-to-do-list
+      def update_todolist(todolist, name, description = nil)
+        url = todolist.url
 
-      raise Camper::Error::InvalidParameter, todolist unless Camper::UrlUtils.basecamp_url?(url)
+        raise Error::InvalidParameter, todolist unless UrlUtils.basecamp_url?(url)
 
-      body = { name: name }
-      body[:description] = description.nil? ? todolist.description : description
+        body = { name: name }
+        body[:description] = description.nil? ? todolist.description : description
 
-      put(url, body: body, override_path: true)
-    end
+        put(url, body: body, override_path: true)
+      end
 
-    # Trash a todolist
-    #   it calls the trash_recording endpoint under the hood
-    #
-    # @example
-    #   client.trash_todolist(todolist)
-    #
-    # @param todolist [Resource] the todolist to be trashed
-    # @raise [Error::InvalidParameter] if the type field in todolist param
-    #   is not an allowed type in the recording API
-    # @see https://github.com/basecamp/bc3-api/blob/master/sections/recordings.md#trash-a-recording
-    def trash_todolist(todolist)
-      trash_recording(todolist)
+      # Trash a todolist
+      #   it calls the trash_recording endpoint under the hood
+      #
+      # @example
+      #   client.trash_todolist(todolist)
+      #
+      # @param todolist [Resource] the todolist to be trashed
+      # @raise [Error::InvalidParameter] if the type field in todolist param
+      #   is not an allowed type in the recording API
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/recordings.md#trash-a-recording
+      def trash_todolist(todolist)
+        trash_recording(todolist)
+      end
     end
   end
 end

--- a/lib/camper/api/todos.rb
+++ b/lib/camper/api/todos.rb
@@ -1,198 +1,200 @@
 # frozen_string_literal: true
 
-class Camper::Client
-  # Defines methods related to todos.
-  # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md
-  module TodosAPI
-    PARAMETERS = %w[
-      content
-      description
-      assignee_ids
-      completion_subscriber_ids
-      notify
-      due_on
-      starts_on
-    ].freeze
+module Camper
+  class Client
+    # Defines methods related to todos.
+    # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md
+    module TodosAPI
+      PARAMETERS = %w[
+        content
+        description
+        assignee_ids
+        completion_subscriber_ids
+        notify
+        due_on
+        starts_on
+      ].freeze
 
-    # Get the todos in a todolist
-    #
-    # @example
-    #   client.todos(todolist)
-    # @example
-    #   client.todos(todolist, completed: true)
-    #
-    # @param todolist [Resource] the parent todoset resource
-    # @param options [Hash] options to filter the list of todos
-    # @return [Resource]
-    # @raise [Error::InvalidParameter] if todos_url field in todolist param
-    #   is not a valid basecamp url
-    # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#get-to-dos
-    def todos(todolist, options = {})
-      url = todolist.todos_url
+      # Get the todos in a todolist
+      #
+      # @example
+      #   client.todos(todolist)
+      # @example
+      #   client.todos(todolist, completed: true)
+      #
+      # @param todolist [Resource] the parent todoset resource
+      # @param options [Hash] options to filter the list of todos
+      # @return [Resource]
+      # @raise [Error::InvalidParameter] if todos_url field in todolist param
+      #   is not a valid basecamp url
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#get-to-dos
+      def todos(todolist, options = {})
+        url = todolist.todos_url
 
-      raise Camper::Error::InvalidParameter, todolist unless Camper::UrlUtils.basecamp_url?(url)
+        raise Error::InvalidParameter, todolist unless UrlUtils.basecamp_url?(url)
 
-      get(url, query: options, override_path: true)
-    end
-
-    # Get a todo with a given id using a particular parent resource.
-    #
-    # @example
-    #   client.todo(my_project, '10')
-    # @example
-    #   client.todo(new_todolist, 134)
-    # @example
-    #   client.todo(67543, '2440')
-    #
-    # @param parent [Integer|String|Project|Resource] can be either a project id, a project or a todolist resource
-    # @param id [Integer|String] id of the todo
-    # @return [Resource]
-    # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#get-a-to-do
-    def todo(parent, id)
-      bucket_id = parent
-
-      if parent.is_a? Camper::Project
-        bucket_id = parent.id
-      elsif parent.respond_to?(:type)
-        bucket_id = parent.bucket.id
+        get(url, query: options, override_path: true)
       end
 
-      get("/buckets/#{bucket_id}/todos/#{id}")
-    end
+      # Get a todo with a given id using a particular parent resource.
+      #
+      # @example
+      #   client.todo(my_project, '10')
+      # @example
+      #   client.todo(new_todolist, 134)
+      # @example
+      #   client.todo(67543, '2440')
+      #
+      # @param parent [Integer|String|Project|Resource] can be either a project id, a project or a todolist resource
+      # @param id [Integer|String] id of the todo
+      # @return [Resource]
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#get-a-to-do
+      def todo(parent, id)
+        bucket_id = parent
 
-    # Create a todo within a todolist
-    #
-    # @example
-    #   client.create_todo(todolist, 'First Todo')
-    # @example
-    #   client.create_todo(
-    #     todolist,
-    #     'Program it',
-    #     description: "<div><em>Try that new language!</em></div>, due_on: "2016-05-01"
-    #   )
-    #
-    # @param todolist [Resource] the todolist where the todo is going to be created
-    # @param content [String] what the to-do is for
-    # @param options [Hash] extra parameters for the todo such as due_date and description
-    # @return [Resource]
-    # @raise [Error::InvalidParameter] if todos_url field in todolist param
-    #   is not a valid basecamp url
-    # @raise [Error::InvalidParameter] if content parameter is blank
-    # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#create-a-to-do
-    def create_todo(todolist, content, options = {})
-      url = todolist.todos_url
+        if parent.is_a? Camper::Project
+          bucket_id = parent.id
+        elsif parent.respond_to?(:type)
+          bucket_id = parent.bucket.id
+        end
 
-      raise Camper::Error::InvalidParameter, todolist unless Camper::UrlUtils.basecamp_url?(url)
-      raise Camper::Error::InvalidParameter, content if content.blank?
+        get("/buckets/#{bucket_id}/todos/#{id}")
+      end
 
-      post(url, body: { content: content, **options }, override_path: true)
-    end
+      # Create a todo within a todolist
+      #
+      # @example
+      #   client.create_todo(todolist, 'First Todo')
+      # @example
+      #   client.create_todo(
+      #     todolist,
+      #     'Program it',
+      #     description: "<div><em>Try that new language!</em></div>, due_on: "2016-05-01"
+      #   )
+      #
+      # @param todolist [Resource] the todolist where the todo is going to be created
+      # @param content [String] what the to-do is for
+      # @param options [Hash] extra parameters for the todo such as due_date and description
+      # @return [Resource]
+      # @raise [Error::InvalidParameter] if todos_url field in todolist param
+      #   is not a valid basecamp url
+      # @raise [Error::InvalidParameter] if content parameter is blank
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#create-a-to-do
+      def create_todo(todolist, content, options = {})
+        url = todolist.todos_url
 
-    # Update a todo.
-    #
-    # @example
-    #   client.update_todo(todo, 'Todo')
-    # @example
-    #   client.update_todo(
-    #     todo,
-    #     'Program it',
-    #     description: "<div><em>Try that new language!</em></div>,
-    #     due_on: "2016-05-01",
-    #     starts_on: "2016-04-30"
-    #   )
-    #
-    # @param todo [Resource] the todo to be updated
-    # @param options [Hash] parameters to be changed. The ones that are not specified
-    #   will be set to the current values of the todo object
-    # @return [Resource]
-    # @raise [Error::InvalidParameter] if url field in todo param
-    #   is not a valid basecamp url
-    # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#update-a-to-do
-    def update_todo(todo, options)
-      url = todo.url
+        raise Error::InvalidParameter, todolist unless UrlUtils.basecamp_url?(url)
+        raise Error::InvalidParameter, content if content.blank?
 
-      raise Camper::Error::InvalidParameter, url unless Camper::UrlUtils.basecamp_url?(url)
+        post(url, body: { content: content, **options }, override_path: true)
+      end
 
-      body = {}.merge(options)
-      PARAMETERS.each { |p| body[p.to_sym] = todo[p] unless key_is_present?(body, p) }
+      # Update a todo.
+      #
+      # @example
+      #   client.update_todo(todo, 'Todo')
+      # @example
+      #   client.update_todo(
+      #     todo,
+      #     'Program it',
+      #     description: "<div><em>Try that new language!</em></div>,
+      #     due_on: "2016-05-01",
+      #     starts_on: "2016-04-30"
+      #   )
+      #
+      # @param todo [Resource] the todo to be updated
+      # @param options [Hash] parameters to be changed. The ones that are not specified
+      #   will be set to the current values of the todo object
+      # @return [Resource]
+      # @raise [Error::InvalidParameter] if url field in todo param
+      #   is not a valid basecamp url
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#update-a-to-do
+      def update_todo(todo, options)
+        url = todo.url
 
-      put(url, body: body, override_path: true)
-    end
+        raise Error::InvalidParameter, url unless UrlUtils.basecamp_url?(url)
 
-    # Complete a todo
-    #
-    # @example
-    #   client.complete_todo(todo)
-    #
-    # @param todo [Resource] the todo to be marked as completed
-    # @raise [Error::InvalidParameter] if url field in todo param
-    #   is not a valid basecamp url
-    # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#complete-a-to-do
-    def complete_todo(todo)
-      url = todo.url
+        body = {}.merge(options)
+        PARAMETERS.each { |p| body[p.to_sym] = todo[p] unless key_is_present?(body, p) }
 
-      raise Camper::Error::InvalidParameter, todo unless Camper::UrlUtils.basecamp_url?(url)
+        put(url, body: body, override_path: true)
+      end
 
-      post("#{url}/completion", override_path: true)
-    end
+      # Complete a todo
+      #
+      # @example
+      #   client.complete_todo(todo)
+      #
+      # @param todo [Resource] the todo to be marked as completed
+      # @raise [Error::InvalidParameter] if url field in todo param
+      #   is not a valid basecamp url
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#complete-a-to-do
+      def complete_todo(todo)
+        url = todo.url
 
-    # Uncomplete a todo
-    #
-    # @example
-    #   client.uncomplete_todo(todo)
-    #
-    # @param todo [Resource] the todo to be marked as uncompleted
-    # @raise [Error::InvalidParameter] if url field in todo param
-    #   is not a valid basecamp url
-    # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#uncomplete-a-to-do
-    def uncomplete_todo(todo)
-      url = todo.url
+        raise Error::InvalidParameter, todo unless UrlUtils.basecamp_url?(url)
 
-      raise Camper::Error::InvalidParameter, todo unless Camper::UrlUtils.basecamp_url?(url)
+        post("#{url}/completion", override_path: true)
+      end
 
-      delete("#{url}/completion", override_path: true)
-    end
+      # Uncomplete a todo
+      #
+      # @example
+      #   client.uncomplete_todo(todo)
+      #
+      # @param todo [Resource] the todo to be marked as uncompleted
+      # @raise [Error::InvalidParameter] if url field in todo param
+      #   is not a valid basecamp url
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#uncomplete-a-to-do
+      def uncomplete_todo(todo)
+        url = todo.url
 
-    # Reposition a todo
-    #
-    # @example
-    #   client.uncomplete_todo(todo)
-    #
-    # @param todo [Resource] the todo to be repositioned
-    # @param position [Integer|String] new position for the todo
-    # @raise [Error::InvalidParameter] if url field in todo param
-    #   is not a valid basecamp url
-    # @raise [Error::InvalidParameter] if position param is less than 1
-    # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#reposition-a-to-do
-    def reposition_todo(todo, position)
-      url = todo.url
-      raise Camper::Error::InvalidParameter, todo unless Camper::UrlUtils.basecamp_url?(url)
+        raise Error::InvalidParameter, todo unless UrlUtils.basecamp_url?(url)
 
-      raise Camper::Error::InvalidParameter, position if position.to_i < 1
+        delete("#{url}/completion", override_path: true)
+      end
 
-      put("#{url}/position", position: position, override_path: true)
-    end
+      # Reposition a todo
+      #
+      # @example
+      #   client.uncomplete_todo(todo)
+      #
+      # @param todo [Resource] the todo to be repositioned
+      # @param position [Integer|String] new position for the todo
+      # @raise [Error::InvalidParameter] if url field in todo param
+      #   is not a valid basecamp url
+      # @raise [Error::InvalidParameter] if position param is less than 1
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#reposition-a-to-do
+      def reposition_todo(todo, position)
+        url = todo.url
+        raise Error::InvalidParameter, todo unless UrlUtils.basecamp_url?(url)
 
-    # Trash a todo
-    #   it calls the trash_recording endpoint under the hood
-    #
-    # @example
-    #   client.trash_todo(todo)
-    #
-    # @param todo [Resource] the todo to be trashed
-    # @raise [Error::InvalidParameter] if url field in todo param
-    #   is not a valid basecamp url
-    # @see https://github.com/basecamp/bc3-api/blob/master/sections/recordings.md#trash-a-recording
-    def trash_todo(todo)
-      raise Camper::Error::InvalidParameter, todo unless Camper::UrlUtils.basecamp_url?(todo.url)
+        raise Error::InvalidParameter, position if position.to_i < 1
 
-      trash_recording(todo)
-    end
+        put("#{url}/position", position: position, override_path: true)
+      end
 
-    private
+      # Trash a todo
+      #   it calls the trash_recording endpoint under the hood
+      #
+      # @example
+      #   client.trash_todo(todo)
+      #
+      # @param todo [Resource] the todo to be trashed
+      # @raise [Error::InvalidParameter] if url field in todo param
+      #   is not a valid basecamp url
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/recordings.md#trash-a-recording
+      def trash_todo(todo)
+        raise Error::InvalidParameter, todo unless UrlUtils.basecamp_url?(todo.url)
 
-    def key_is_present?(hash, key)
-      hash.key?(key.to_sym) || hash.key?(key.to_s)
+        trash_recording(todo)
+      end
+
+      private
+
+      def key_is_present?(hash, key)
+        hash.key?(key.to_sym) || hash.key?(key.to_s)
+      end
     end
   end
 end

--- a/spec/components/api/comments_spec.rb
+++ b/spec/components/api/comments_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe Camper::Client::CommentsAPI do
   context 'errors' do
     context '#create_comment' do
       it 'raises an error if the resource cannot be commented on' do
-        resource = Camper::Resource.create({url: 'https://3.basecampapi.com'})
+        resource = Camper::Resource.create({ url: 'https://3.basecampapi.com' })
 
-        expect{ @client.create_comment(resource, 'Hello World') }.to raise_error(Camper::Error::ResourceCannotBeCommented)
+        expect { @client.create_comment(resource, 'Hello World') }.to raise_error(Camper::Error::ResourceCannotBeCommented)
       end
     end
   end

--- a/spec/components/api/comments_spec.rb
+++ b/spec/components/api/comments_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe Camper::Client::CommentsAPI do
+  before(:all) do
+    @client = Camper.client
+  end
+
+  context 'errors' do
+    context '#create_comment' do
+      it 'raises an error if the resource cannot be commented on' do
+        resource = Camper::Resource.create({url: 'https://3.basecampapi.com'})
+
+        expect{ @client.create_comment(resource, 'Hello World') }.to raise_error(Camper::Error::ResourceCannotBeCommented)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This eliminates the need to prefix with `Camper::` when calling classes within the API modules definitions

## Changes

* Added initial comments tests
* Remove unneeded `Camper::` prefix after refactoring