### PR TITLE
Refactor check for valid basecamp url

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,9 @@ Layout/LineLength:
     - 'lib/camper/client/*'
     - 'spec/**/*'
 
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'

--- a/lib/camper/api/todolists.rb
+++ b/lib/camper/api/todolists.rb
@@ -19,11 +19,7 @@ module Camper
       #   is not a valid basecamp url
       # @see https://github.com/basecamp/bc3-api/blob/master/sections/todolists.md#get-to-do-lists
       def todolists(todoset, options = {})
-        url = todoset.todolists_url
-
-        raise Error::InvalidParameter, todoset unless UrlUtils.basecamp_url?(url)
-
-        get(url, query: options, override_path: true)
+        get(todoset.todolists_url, query: options, override_path: true)
       end
 
       # Get a todolist with a given id
@@ -52,11 +48,9 @@ module Camper
       #   is not a valid basecamp url
       # @see https://github.com/basecamp/bc3-api/blob/master/sections/todolists.md#create-a-to-do-list
       def create_todolist(todoset, name, description = '')
-        url = todoset.todolists_url
+        body = { name: name, description: description }
 
-        raise Error::InvalidParameter, todoset unless UrlUtils.basecamp_url?(url)
-
-        post(url, body: { name: name, description: description }, override_path: true)
+        post(todoset.todolists_url, body: body, override_path: true)
       end
 
       # Update a todolist to change name and description
@@ -77,14 +71,10 @@ module Camper
       #   is not a valid basecamp url
       # @see https://github.com/basecamp/bc3-api/blob/master/sections/todolists.md#update-a-to-do-list
       def update_todolist(todolist, name, description = nil)
-        url = todolist.url
-
-        raise Error::InvalidParameter, todolist unless UrlUtils.basecamp_url?(url)
-
         body = { name: name }
         body[:description] = description.nil? ? todolist.description : description
 
-        put(url, body: body, override_path: true)
+        put(todolist.url, body: body, override_path: true)
       end
 
       # Trash a todolist

--- a/lib/camper/api/todos.rb
+++ b/lib/camper/api/todos.rb
@@ -22,18 +22,14 @@ module Camper
       # @example
       #   client.todos(todolist, completed: true)
       #
-      # @param todolist [Resource] the parent todoset resource
+      # @param todolist [Resource] the parent todolist resource
       # @param options [Hash] options to filter the list of todos
       # @return [Resource]
       # @raise [Error::InvalidParameter] if todos_url field in todolist param
       #   is not a valid basecamp url
       # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#get-to-dos
       def todos(todolist, options = {})
-        url = todolist.todos_url
-
-        raise Error::InvalidParameter, todolist unless UrlUtils.basecamp_url?(url)
-
-        get(url, query: options, override_path: true)
+        get(todolist.todos_url, query: options, override_path: true)
       end
 
       # Get a todo with a given id using a particular parent resource.
@@ -81,12 +77,9 @@ module Camper
       # @raise [Error::InvalidParameter] if content parameter is blank
       # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#create-a-to-do
       def create_todo(todolist, content, options = {})
-        url = todolist.todos_url
-
-        raise Error::InvalidParameter, todolist unless UrlUtils.basecamp_url?(url)
         raise Error::InvalidParameter, content if content.blank?
 
-        post(url, body: { content: content, **options }, override_path: true)
+        post(todolist.todos_url, body: { content: content, **options }, override_path: true)
       end
 
       # Update a todo.
@@ -110,14 +103,10 @@ module Camper
       #   is not a valid basecamp url
       # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#update-a-to-do
       def update_todo(todo, options)
-        url = todo.url
-
-        raise Error::InvalidParameter, url unless UrlUtils.basecamp_url?(url)
-
         body = {}.merge(options)
         PARAMETERS.each { |p| body[p.to_sym] = todo[p] unless key_is_present?(body, p) }
 
-        put(url, body: body, override_path: true)
+        put(todo.url, body: body, override_path: true)
       end
 
       # Complete a todo
@@ -130,11 +119,7 @@ module Camper
       #   is not a valid basecamp url
       # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#complete-a-to-do
       def complete_todo(todo)
-        url = todo.url
-
-        raise Error::InvalidParameter, todo unless UrlUtils.basecamp_url?(url)
-
-        post("#{url}/completion", override_path: true)
+        post("#{todo.url}/completion", override_path: true)
       end
 
       # Uncomplete a todo
@@ -147,11 +132,7 @@ module Camper
       #   is not a valid basecamp url
       # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#uncomplete-a-to-do
       def uncomplete_todo(todo)
-        url = todo.url
-
-        raise Error::InvalidParameter, todo unless UrlUtils.basecamp_url?(url)
-
-        delete("#{url}/completion", override_path: true)
+        delete("#{todo.url}/completion", override_path: true)
       end
 
       # Reposition a todo
@@ -166,12 +147,9 @@ module Camper
       # @raise [Error::InvalidParameter] if position param is less than 1
       # @see https://github.com/basecamp/bc3-api/blob/master/sections/todos.md#reposition-a-to-do
       def reposition_todo(todo, position)
-        url = todo.url
-        raise Error::InvalidParameter, todo unless UrlUtils.basecamp_url?(url)
-
         raise Error::InvalidParameter, position if position.to_i < 1
 
-        put("#{url}/position", position: position, override_path: true)
+        put("#{todo.url}/position", position: position, override_path: true)
       end
 
       # Trash a todo
@@ -185,8 +163,6 @@ module Camper
       #   is not a valid basecamp url
       # @see https://github.com/basecamp/bc3-api/blob/master/sections/recordings.md#trash-a-recording
       def trash_todo(todo)
-        raise Error::InvalidParameter, todo unless UrlUtils.basecamp_url?(todo.url)
-
         trash_recording(todo)
       end
 

--- a/lib/camper/error.rb
+++ b/lib/camper/error.rb
@@ -17,6 +17,8 @@ module Camper
 
     class RequestIsMissingParameters < Error; end
 
+    class InvalidURL < Error; end
+
     class InvalidParameter < Error; end
 
     # Raised when impossible to parse response body.

--- a/lib/camper/request.rb
+++ b/lib/camper/request.rb
@@ -63,6 +63,7 @@ module Camper
     def execute
       endpoint, params = prepare_request_data
 
+      raise Error::InvalidURL, endpoint unless UrlUtils.basecamp_url?(endpoint)
       raise Error::TooManyRetries, endpoint if maxed_attempts?
 
       @attempts += 1

--- a/spec/components/api/todolists_spec.rb
+++ b/spec/components/api/todolists_spec.rb
@@ -2,40 +2,46 @@
 
 RSpec.describe Camper::Client::TodolistsAPI do
   before(:all) do
-    @client = Camper.client
+    @client = Camper.configure do |config|
+      config.access_token = 'access-token'
+      config.account_number = '00000'
+    end
   end
-
-  let(:test_class_todoset) { Struct.new(:todolists_url) }
-  let(:test_class_todolist) { Struct.new(:url, :type) }
 
   context 'errors' do
     context '#todolists' do
       it 'raises an error if todolists_url field is not a valid basecamp url' do
-        todoset = test_class_todoset.new('https://twitter.com')
+        todoset = Camper::Resource.create({ todolists_url: 'https://twitter.com' })
 
-        expect { @client.todolists(todoset) }.to raise_error(Camper::Error::InvalidParameter)
+        expect { @client.todolists(todoset) }.to raise_error(Camper::Error::InvalidURL)
       end
     end
 
     context '#create_todolist' do
       it 'raises an error if todolists_url field is not a valid basecamp url' do
-        todoset = test_class_todoset.new('https://twitter.com')
+        todoset = Camper::Resource.create({ todolists_url: 'https://twitter.com' })
 
-        expect { @client.create_todolist(todoset, 'Hello World') }.to raise_error(Camper::Error::InvalidParameter)
+        expect { @client.create_todolist(todoset, 'Hello World') }.to raise_error(Camper::Error::InvalidURL)
       end
     end
 
     context '#update_todolist' do
       it 'raises an error if todolists_url field is not a valid basecamp url' do
-        todolist = test_class_todolist.new('https://twitter.com')
+        todolist = Camper::Resource.create({
+          url: 'https://twitter.com',
+          description: 'description'
+        })
 
-        expect { @client.update_todolist(todolist, 'Hello World') }.to raise_error(Camper::Error::InvalidParameter)
+        expect { @client.update_todolist(todolist, 'Hello World') }.to raise_error(Camper::Error::InvalidURL)
       end
     end
 
     context '#trash_todolist' do
       it 'raises an error if type field is not a valid type' do
-        todolist = test_class_todolist.new('https://3.basecamp.com/1234/projects', 'Project')
+        todolist = Camper::Resource.create({
+          url: 'https://twitter.com',
+          type: 'Project'
+        })
 
         expect { @client.trash_todolist(todolist) }.to raise_error(Camper::Error::InvalidParameter)
       end

--- a/spec/components/api/todos_spec.rb
+++ b/spec/components/api/todos_spec.rb
@@ -2,30 +2,32 @@
 
 RSpec.describe Camper::Client::TodosAPI do
   before(:all) do
-    @client = Camper.client
+    @client = Camper.configure do |config|
+      config.access_token = 'access-token'
+      config.account_number = '00000'
+    end
   end
-
-  let(:test_class_todolist) { Struct.new(:todos_url) }
-  let(:test_class_todo) { Struct.new(:url, :type) }
 
   context 'errors' do
     context '#todos' do
       it 'raises an error if todos_url field is not a valid basecamp url' do
-        todolist = test_class_todolist.new('https://twitter.com')
+        todolist = Camper::Resource.create({ todos_url: 'https://twitter.com' })
 
-        expect { @client.todos(todolist) }.to raise_error(Camper::Error::InvalidParameter)
+        expect { @client.todos(todolist) }.to raise_error(Camper::Error::InvalidURL)
       end
     end
 
     context '#create_todo' do
       it 'raises an error if todos_url field is not a valid basecamp url' do
-        todolist = test_class_todolist.new('https://twitter.com')
+        todolist = Camper::Resource.create({ todos_url: 'https://twitter.com' })
 
-        expect { @client.create_todo(todolist, 'Hello World') }.to raise_error(Camper::Error::InvalidParameter)
+        expect { @client.create_todo(todolist, 'Hello World') }.to raise_error(Camper::Error::InvalidURL)
       end
 
       it 'raises an error if content parameter is blank' do
-        todolist = test_class_todolist.new('https://3.basecamp.com/1234/todolists/1/todos.json')
+        todolist = Camper::Resource.create({
+          url: 'https://3.basecamp.com/1234/todolists/1/todos.json'
+        })
 
         expect { @client.create_todo(todolist, '') }.to raise_error(Camper::Error::InvalidParameter)
       end
@@ -33,51 +35,48 @@ RSpec.describe Camper::Client::TodosAPI do
 
     context '#update_todo' do
       it 'raises an error if todos_url field is not a valid basecamp url' do
-        todo = test_class_todo.new('https://twitter.com')
+        todo = Camper::Resource.create({ url: 'https://twitter.com' })
 
-        expect { @client.update_todo(todo, {}) }.to raise_error(Camper::Error::InvalidParameter)
+        expect { @client.update_todo(todo, {}) }.to raise_error(Camper::Error::InvalidURL)
       end
     end
 
     context '#complete_todo' do
       it 'raises an error if url field is not a valid basecamp url' do
-        todo = test_class_todo.new('https://twitter.com')
+        todo = Camper::Resource.create({ url: 'https://twitter.com' })
 
-        expect { @client.complete_todo(todo) }.to raise_error(Camper::Error::InvalidParameter)
+        expect { @client.complete_todo(todo) }.to raise_error(Camper::Error::InvalidURL)
       end
     end
 
     context '#uncomplete_todo' do
       it 'raises an error if url field is not a valid basecamp url' do
-        todo = test_class_todo.new('https://twitter.com')
+        todo = Camper::Resource.create({ url: 'https://twitter.com' })
 
-        expect { @client.uncomplete_todo(todo) }.to raise_error(Camper::Error::InvalidParameter)
+        expect { @client.uncomplete_todo(todo) }.to raise_error(Camper::Error::InvalidURL)
       end
     end
 
     context '#reposition_todo' do
       it 'raises an error if url field is not a valid basecamp url' do
-        todo = test_class_todo.new('https://twitter.com')
+        todo = Camper::Resource.create({ url: 'https://twitter.com' })
 
-        expect { @client.reposition_todo(todo, 20) }.to raise_error(Camper::Error::InvalidParameter)
+        expect { @client.reposition_todo(todo, 20) }.to raise_error(Camper::Error::InvalidURL)
       end
 
       it 'raises an error if position param is less than 1' do
-        todo = test_class_todo.new('https://3.basecamp.com/1234/projects')
+        todo = Camper::Resource.create({ url: 'https://3.basecamp.com/1234/projects' })
 
         expect { @client.reposition_todo(todo, '0') }.to raise_error(Camper::Error::InvalidParameter)
       end
     end
 
     context '#trash_todo' do
-      it 'raises an error if url field is not a valid basecamp url' do
-        todo = test_class_todo.new('https://twitter.com')
-
-        expect { @client.trash_todo(todo) }.to raise_error(Camper::Error::InvalidParameter)
-      end
-
       it 'raises an error if type field is not a valid type' do
-        todo = test_class_todo.new('https://3.basecamp.com/1234/projects', 'Project')
+        todo = Camper::Resource.create({
+          url: 'https://3.basecamp.com/1234/projects',
+          type: 'Project'
+        })
 
         expect { @client.trash_todo(todo) }.to raise_error(Camper::Error::InvalidParameter)
       end

--- a/spec/components/request_spec.rb
+++ b/spec/components/request_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe Camper::Request do
     @request = described_class.new(@client, :get, '/url/path')
   end
 
+  context 'errors' do
+    it 'fails if url is not a valid basecamp url' do
+      request = described_class.new(@client, :get, 'www.twitter.com', override_path: true)
+
+      expect { request.execute }.to raise_error(Camper::Error::InvalidURL)
+    end
+  end
+
   describe '.default_options' do
     it 'has default values' do
       default_options = described_class.default_options

--- a/spec/system/errors_spec.rb
+++ b/spec/system/errors_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Camper::Client do
     @client = Camper.configure do |config|
       config.client_id = 'client_id'
       config.client_secret = 'client_secret'
-      config.account_number = 'account_number'
+      config.account_number = '00000000'
       config.refresh_token = 'refresh_token'
       config.access_token = 'access_token'
     end


### PR DESCRIPTION
## Description

Simplify API endpoints code by moving down to the `Request` class the check for whether the url is a valid basecamp URL.

## Changes

* Move client check for valid Basecamp url down to the `Request` class in the `execute` method (before API invocation)
* Update specs to check for new error
* Remove test classes and use `Resource` class directly in specs